### PR TITLE
chore: add entrypoint to run the tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+.PHONY: test
+test:
+	dotnet test --logger:"console;verbosity=detailed"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,11 @@ dotnet test --logger:"console;verbosity=detailed"
 
 ## Run the test suite
 
-`dotnet test --logger:"console;verbosity=detailed"`
+```shell
+make test
+```
+
+The `Make` command will run the test suite using `dotnet test --logger:"console;verbosity=detailed"`
 
 ### Confirm your environment is configured correctly
 

--- a/README.md
+++ b/README.md
@@ -5,15 +5,9 @@ For details on how to bootstrap Testcontainers in an actual project, please refe
 
 ## Clone the repository and run the first Testcontainers test suite
 
-```
+```shell
 git clone https://github.com/AtomicJar/testcontainers-cloud-dotnet-example
 cd testcontainers-cloud-dotnet-example
-dotnet test --logger:"console;verbosity=detailed"
-```
-
-## Run the test suite
-
-```shell
 make test
 ```
 


### PR DESCRIPTION
## What does this PR do?
It adds an entrypoint using Make to run the tests with just a single command

## Why is it important?
It will implement the contract of all cloud examples to run tests with the very same command
 

